### PR TITLE
Copy edit pass through the README

### DIFF
--- a/crates/brk_cli/README.md
+++ b/crates/brk_cli/README.md
@@ -1,5 +1,80 @@
 # BRK Cli
 
+A command line interface to interact with the full Bitcoin Research Kit. It's built on top of every 
+other create and gives the possility to use BRK using the terminal instead of Rust.
+
+It has 2 commands (other than `help` and `version`) which are `run` and `query`. The former is used 
+to run the processing (indexer + computer) and/or the server. The latter uses `brk_query` as its 
+backend just like to server to be able to get datasets via the terminal instead of the API. Both 
+commands are custumizable by supporting all the parameters of their Rust counterparts 
+([`run`](https://github.com/bitcoinresearchkit/brk/blob/c9c6b583338203b2b11bdf31e961b1c306f5d82b/crates/brk_cli/src/run.rs#L110-L191), 
+and [`query`](https://github.com/bitcoinresearchkit/brk/blob/main/crates/brk_query/src/params.rs)).
+
+## Requirements
+
+### Hardware
+
+#### Recommended
+
+- [Latest base model Mac mini](https://www.apple.com/mac-mini/)
+- [Thunderbolt 4 SSD enclosure](https://satechi.net/products/usb4-nvme-ssd-pro-enclosure/Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC80MDE4ODQ3MDA2NzI4OA==?queryID=7961465089021ee203a60db7e62e90d2)
+- [2 TB NVMe SSD](https://shop.sandisk.com/products/ssd/internal-ssd/wd-black-sn850x-nvme-ssd?sku=WDS200T2X0E-00BCA0)
+
+#### Minimum
+
+To be determined
+
+### Software
+
+- [Bitcoin](https://bitcoin.org/en/full-node)
+- [Rust](https://www.rust-lang.org/tools/install)
+- Unix based operating system (Mac OS or Linux)
+
+> [!IMPORTANT]  
+> Ubuntu users need to install `open-ssl` via `sudo apt install libssl-dev pkg-config`
+
+
+## Download
+
+### Binaries
+
+You can find a pre-built binary for your operating system in the 
+[releases page](https://github.com/bitcoinresearchkit/brk/releases/latest).
+
+### Cargo
+
+```bash
+# Install
+cargo install brk # or `cargo install brk_cli`, the result is the same
+
+# Update
+cargo install brk # or `cargo install-update -a` if you have `cargo-update` installed
+```
+
+### Source
+
+```bash
+git clone https://github.com/bitcoinresearchkit/brk.git
+cd brk/crates/brk
+cargo run -r
+```
+
+## Usage
+
+Run `brk -h` to view each available command and their respective description.
+
+`-h` works also for commands, so `brk run -h` will enumerate all the parameters of `brk run`.
+
+> [!TIP]  
+> Every parameter set for `brk run` will be saved at `~/.brk/config.toml`, which allows you to simply run `brk run` next time.
+
+
+The easiest way to let others access your server is to use `cloudflared` which will also cache 
+requests. For more information see 
+[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) 
+documentation.
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -30,67 +105,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A command line interface to interact with the full Bitcoin Research Kit. It's built on top of every other create and gives the possility to use BRK using the terminal instead of Rust.
-
-It has 2 commands (other than `help` and `version`) which are `run` and `query`. The former is used to run the processing (indexer + computer) and/or the server. The latter uses `brk_query` as its backend just like to server to be able to get datasets via the terminal instead of the API. Both commands are custumizable by supporting all the parameters of their Rust counterparts ([`run`](https://github.com/bitcoinresearchkit/brk/blob/c9c6b583338203b2b11bdf31e961b1c306f5d82b/crates/brk_cli/src/run.rs#L110-L191), and [`query`](https://github.com/bitcoinresearchkit/brk/blob/main/crates/brk_query/src/params.rs)).
-
-## Requirements
-
-### Hardware
-
-#### Recommended
-
-- [Latest base model Mac mini](https://www.apple.com/mac-mini/)
-- [Thunderbolt 4 SSD enclosure](https://satechi.net/products/usb4-nvme-ssd-pro-enclosure/Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC80MDE4ODQ3MDA2NzI4OA==?queryID=7961465089021ee203a60db7e62e90d2)
-- [2 TB NVMe SSD](https://shop.sandisk.com/products/ssd/internal-ssd/wd-black-sn850x-nvme-ssd?sku=WDS200T2X0E-00BCA0)
-
-#### Minimum
-
-To be determined
-
-### Software
-
-- [Bitcoin](https://bitcoin.org/en/full-node)
-- [Rust](https://www.rust-lang.org/tools/install)
-- Unix based operating system (Mac OS or Linux)
-
-> [!IMPORTANT]  
-> Ubuntu users need to install `open-ssl` via `sudo apt install libssl-dev pkg-config`
-
-
-## Download
-
-### Binaries
-
-You can find a pre-built binary for your operating system in the [releases page](https://github.com/bitcoinresearchkit/brk/releases/latest).
-
-### Cargo
-
-```bash
-# Install
-cargo install brk # or `cargo install brk_cli`, the result is the same
-
-# Update
-cargo install brk # or `cargo install-update -a` if you have `cargo-update` installed
-```
-
-### Source
-
-```bash
-git clone https://github.com/bitcoinresearchkit/brk.git
-cd brk/crates/brk
-cargo run -r
-```
-
-## Usage
-
-Run `brk -h` to view each available command and their respective description.
-
-`-h` works also for commands, so `brk run -h` will enumerate all the parameters of `brk run`.
-
-> [!TIP]  
-> Every parameter set for `brk run` will be saved at `~/.brk/config.toml`, which allows you to simply run `brk run` next time.
-
-
-The easiest way to let others access your server is to use `cloudflared` which will also cache requests. For more information see [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) documentation.

--- a/crates/brk_core/README.md
+++ b/crates/brk_core/README.md
@@ -1,5 +1,9 @@
 # BRK Core
 
+Structs that are used throughout the project as units, think of `Date`, `Height`, `Sats`,
+`Txindex`... or anything that can be either a key and/or a value of a dataset.
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +11,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_core">
-    <img src="https://img.shields.io/crates/v/brk_core" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_core">
-    <img src="https://img.shields.io/docsrs/brk_core" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_core" alt="Size" />
-  <a href="https://deps.rs/crate/brk_core">
-    <img src="https://deps.rs/crate/brk_core/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,5 +34,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A list of structs that are used throughout the project as units, think of `Date`, `Height`, `Sats`, `Txindex` or anything that can be either a key and/or a value of a dataset.

--- a/crates/brk_exit/README.md
+++ b/crates/brk_exit/README.md
@@ -1,5 +1,14 @@
 # BRK Exit
 
+A simple crate that stops the program from exitting when blocking is activated until it is released. 
+The purpose of BRK Exit is to prevent exitting when a program is in the middle of saving data and 
+thus preventing partial writes.
+
+It's built on top of [ctrlc](https://crates.io/crates/ctrlc) which handles Ctrl + C (SIGINT), 
+stopping the program using the `kill` command (SIGTERM) and closing the terminal (SIGHUP) but it 
+doesn't support force kills (`kill -9`).
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +16,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_exit">
-    <img src="https://img.shields.io/crates/v/brk_exit" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_exit">
-    <img src="https://img.shields.io/docsrs/brk_exit" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_exit" alt="Size" />
-  <a href="https://deps.rs/crate/brk_exit">
-    <img src="https://deps.rs/crate/brk_exit/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,7 +39,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A simple crate that stops the program from exitting when blocking is activated until it is released. The purpose of that is to prevent exitting when a program is in the middle of saving data and thus prevent partial writes.
-
-It's built on top of [ctrlc](https://crates.io/crates/ctrlc) which handles Ctrl + C (SIGINT), stopping the program using the `kill` command (SIGTERM) and closing the terminal (SIGHUP) but it doesn't support force kills (`kill -9`).

--- a/crates/brk_fetcher/README.md
+++ b/crates/brk_fetcher/README.md
@@ -1,5 +1,8 @@
 # BRK Fetcher
 
+A crate that can fetch the Bitcoin price, either by date or height, from Binance and Kibo.
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +10,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_fetcher">
-    <img src="https://img.shields.io/crates/v/brk_fetcher" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_fetcher">
-    <img src="https://img.shields.io/docsrs/brk_fetcher" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_fetcher" alt="Size" />
-  <a href="https://deps.rs/crate/brk_fetcher">
-    <img src="https://deps.rs/crate/brk_fetcher/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,5 +33,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A crate that can fetch the Bitcoin price, either by date or height, from Binance and Kibo.

--- a/crates/brk_indexer/README.md
+++ b/crates/brk_indexer/README.md
@@ -1,44 +1,18 @@
 # BRK Indexer
 
-<p align="left">
-  <a href="https://github.com/bitcoinresearchkit/brk">
-    <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
-  </a>
-  <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
-    <img src="https://img.shields.io/crates/l/brk" alt="License" />
-  </a>
-  <a href="https://crates.io/crates/brk_indexer">
-    <img src="https://img.shields.io/crates/v/brk_indexer" alt="Version" />
-  </a>
-  <a href="https://docs.rs/brk_indexer">
-    <img src="https://img.shields.io/docsrs/brk_indexer" alt="Documentation" />
-  </a>
-  <img src="https://img.shields.io/crates/size/brk_indexer" alt="Size" />
-  <a href="https://deps.rs/crate/brk_indexer">
-    <img src="https://deps.rs/crate/brk_indexer/latest/status.svg" alt="Dependency status">
-  </a>
-  <a href="https://discord.gg/HaR3wpH3nr">
-    <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
-  </a>
-  <a href="https://primal.net/p/nprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6">
-    <img src="https://img.shields.io/badge/nostr-purple?link=https%3A%2F%2Fprimal.net%2Fp%2Fnprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6" alt="Nostr" />
-  </a>
-  <a href="https://bsky.app/profile/bitcoinresearchkit.org">
-    <img src="https://img.shields.io/badge/bluesky-blue?link=https%3A%2F%2Fbsky.app%2Fprofile%2Fbitcoinresearchkit.org" alt="Bluesky" />
-  </a>
-  <a href="https://x.com/brkdotorg">
-    <img src="https://img.shields.io/badge/x.com-black" alt="X" />
-  </a>
-</p>
+A [Bitcoin Core](https://bitcoincore.org/en/about/) node indexer which iterates over the chain 
+(via `../brk_parser`) and creates a database of the vecs (`brk_vec`) and key/value stores 
+([`fjall`](https://crates.io/crates/fjall)) that can be used in your Rust code.
 
-A [Bitcoin Core](https://bitcoincore.org/en/about/) node indexer which iterates over the chain (via `../brk_parser`) and creates a database of the vecs (`brk_vec`) and key/value stores ([`fjall`](https://crates.io/crates/fjall)) that can be used in your Rust code.
-
-The crate only stores the bare minimum to be self sufficient and not have to use an RPC client (except for scripts which are not stored). If you need more data, checkout `../computer` which uses the outputs from the indexer to compute a whole range of datasets.
+The crate only stores the bare minimum to be self sufficient and not have to use an RPC client 
+(except for scripts which are not stored). If you need more data, checkout `../computer` which uses 
+the outputs from the indexer to compute a whole range of datasets.
 
 Vecs are used sparingly instead of stores for multiple reasons:
 
 - Only stores the relevant data since the key is an index
-- Saved as uncompressed bytes and thus can be parsed manually (with any programming language) without relying on a server or library
+- Saved as uncompressed bytes and thus can be parsed manually (with any programming language) 
+without relying on a server or library
 - Easy to work with and predictable
 
 ## Usage
@@ -73,3 +47,35 @@ Stores: `src/storage/stores/mod.rs`
 - disk usage: `208 GB`
 - overhead: `28%` (`208 GB / 744 GB`)
 - peak memory: `5.7GB`
+
+----
+<p align="left">
+  <a href="https://github.com/bitcoinresearchkit/brk">
+    <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
+  </a>
+  <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
+    <img src="https://img.shields.io/crates/l/brk" alt="License" />
+  </a>
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
+  </a>
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
+  </a>
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
+  </a>
+  <a href="https://discord.gg/HaR3wpH3nr">
+    <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
+  </a>
+  <a href="https://primal.net/p/nprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6">
+    <img src="https://img.shields.io/badge/nostr-purple?link=https%3A%2F%2Fprimal.net%2Fp%2Fnprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6" alt="Nostr" />
+  </a>
+  <a href="https://bsky.app/profile/bitcoinresearchkit.org">
+    <img src="https://img.shields.io/badge/bluesky-blue?link=https%3A%2F%2Fbsky.app%2Fprofile%2Fbitcoinresearchkit.org" alt="Bluesky" />
+  </a>
+  <a href="https://x.com/brkdotorg">
+    <img src="https://img.shields.io/badge/x.com-black" alt="X" />
+  </a>
+</p>

--- a/crates/brk_logger/README.md
+++ b/crates/brk_logger/README.md
@@ -1,5 +1,10 @@
 # BRK Logger
 
+A simple crate built on top of [`env_logger`](https://crates.io/crates/env_logger) to display logs 
+from the [`log`](https://crates.io/crates/log) crate in a colorful and clean format.   It can also 
+save logs to file.
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +12,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_logger">
-    <img src="https://img.shields.io/crates/v/brk_logger" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_logger">
-    <img src="https://img.shields.io/docsrs/brk_logger" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_logger" alt="Size" />
-  <a href="https://deps.rs/crate/brk_logger">
-    <img src="https://deps.rs/crate/brk_logger/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,7 +35,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A simple crate built on top of [`env_logger`](https://crates.io/crates/env_logger) to display logs from the [`log`](https://crates.io/crates/log) crate in a colorful and clean format.
-
-It can also save logs into a file if desired.

--- a/crates/brk_parser/README.md
+++ b/crates/brk_parser/README.md
@@ -1,5 +1,46 @@
 # BRK Parser
 
+This Rust library reads raw block files (like `blkXXXXX.dat`) from Bitcoin Core data, and creates an iterator over the 
+requested range of blocks in sequential order.
+
+The element returned by the iterator is a tuple consisting of:
+- the block `Height`
+- the `Block` (from `bitcoin-rust`), and
+- the block's `BlockHash` (also from `bitcoin-rust`)
+
+Tested with Bitcoin Core `v25.0..=v28.1`
+
+## Requirements
+
+Even though this parser reads `blkXXXXX.dat` files directly, it **needs** `bitcoind` running to provide the RPC Server 
+to filter out blockchain tip-forks.
+
+Peak RAM required should be around 500 MB.
+
+XOR-ed blocks are supported.
+
+## Disclaimer
+
+> [!IMPORTANT]  
+> A state of the local chain is saved in `{bitcoindir}/blocks/blk_index_to_blk_recap.json` to allow for faster starts (see benchmark below) but presently doesn't support locking. Therfore you should run only one instance of `brk_parser` at a time.
+
+## Benchmark
+
+|  | [brk_parser](https://crates.io/crates/brk_parser) | [bitcoin-explorer (deprecated)](https://crates.io/crates/bitcoin-explorer) | [blocks_iterator](https://crates.io/crates/blocks_iterator)* |
+| --- | --- | --- | --- |
+| Runs **with** `bitcoind` | Yes ✅ | No ❌ | Yes ✅ |
+| Runs **without** `bitcoind` | No ❌ | Yes ✅ | Yes ✅ |
+| `0..=855_000` | 4mn 10s | 4mn 45s | > 2h |
+| `800_000..=855_000` | 0mn 52s (4mn 10s if first run) | 0mn 55s | > 2h |
+
+\* `blocks_iterator` is with the default config (and thus with `skip_prevout = false` which does 
+much more than just iterate over blocks) so this isn't strictly an apples to apples comparison.  
+So the results are somewhat misleading. You should expect much closer times. Will update the 
+benchmark with `skip_prevout = true` as soon as possible.
+
+*Benchmarked on a Macbook Pro M3 Pro*
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +48,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_parser">
-    <img src="https://img.shields.io/crates/v/brk_parser" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_parser">
-    <img src="https://img.shields.io/docsrs/brk_parser" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_parser" alt="Size" />
-  <a href="https://deps.rs/crate/brk_parser">
-    <img src="https://deps.rs/crate/brk_parser/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,37 +71,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A very fast and simple Rust library which reads raw block files (*blkXXXXX.dat*) from Bitcoin Core node and creates an iterator over all the requested blocks in sequential order (0, 1, 2, ...).
-
-The element returned by the iterator is a tuple which includes the:
-- Height: `Height`
-- Block: `Block` (from `bitcoin-rust`)
-- Block's Hash: `BlockHash` (also from `bitcoin-rust`)
-
-Tested with Bitcoin Core `v25.0..=v28.1`
-
-## Requirements
-
-Even though it reads *blkXXXXX.dat* files, it **needs** `bitcoind` (with no particular parameters) to run with the RPC server to filter out forks.
-
-Peak memory should be around 500MB.
-
-XOR-ed blocks are supported.
-
-## Disclaimer
-
-A state of the local chain is saved in `{bitcoindir}/blocks/blk_index_to_blk_recap.json` to allow for faster starts (see benchmark below) but doesn't yet support locking. Thus, it is highly recommended to run one instance of `brk_parser` at a time.
-
-## Benchmark
-
-|  | [brk_parser](https://crates.io/crates/brk_parser) | [bitcoin-explorer (deprecated)](https://crates.io/crates/bitcoin-explorer) | [blocks_iterator](https://crates.io/crates/blocks_iterator)* |
-| --- | --- | --- | --- |
-| Runs **with** `bitcoind` | Yes ✅ | No ❌ | Yes ✅ |
-| Runs **without** `bitcoind` | No ❌ | Yes ✅ | Yes ✅ |
-| `0..=855_000` | 4mn 10s | 4mn 45s | > 2h |
-| `800_000..=855_000` | 0mn 52s (4mn 10s if first run) | 0mn 55s | > 2h |
-
-\* `blocks_iterator` is with the default config (and thus with `skip_prevout = false` which does a lot more than just iterate over blocks) so it isn't an apples to apples comparaison and the numbers are misleading. You should expect much closer times. Will update the benchmark with `skip_prevout = true` as soon as possible.
-
-*Benchmarked on a Macbook Pro M3 Pro*

--- a/crates/brk_query/README.md
+++ b/crates/brk_query/README.md
@@ -10,7 +10,7 @@ The output will depend on the format chosen which can be Markdown, Json, CSV or 
 if there is a one or multiple datasets, and if one dataset one or multiple values.
 
 > [!NOTE]  
->In the future, BRK Query gradually acquire features such as: SQL queries, and the ability to fetch data by address, transaction ID, block hash, or block height, among others.
+>In the future, BRK Query will gradually acquire features such as: SQL queries, and the ability to fetch data by address, transaction ID, block hash, or block height, among others.
 
 ----
 <p align="left">

--- a/crates/brk_query/README.md
+++ b/crates/brk_query/README.md
@@ -10,7 +10,7 @@ The output will depend on the format chosen which can be Markdown, Json, CSV or 
 if there is a one or multiple datasets, and if one dataset one or multiple values.
 
 > [!NOTE]  
->In the future, BRK Query will gradually acquire features such as: SQL queries, and the ability to fetch data by address, transaction ID, block hash, or block height, among others.
+>In the future, BRK Query will gradually acquire features such as: SQL queries and the ability to fetch data by address, transaction ID, block hash, or block height, among others.
 
 ----
 <p align="left">

--- a/crates/brk_query/README.md
+++ b/crates/brk_query/README.md
@@ -1,5 +1,18 @@
 # BRK Query
 
+A crate that searches for datasets from either `brk_indexer` or `brk_computer` according to given 
+parameters.
+
+It's possible to search for one or multiple dataset if they have the same index and specify range 
+with both the `from` and `to` being optional and supporting negative values.
+
+The output will depend on the format chosen which can be Markdown, Json, CSV or TSV and might vary 
+if there is a one or multiple datasets, and if one dataset one or multiple values.
+
+> [!NOTE]  
+>In the future, BRK Query gradually acquire features such as: SQL queries, and the ability to fetch data by address, transaction ID, block hash, or block height, among others.
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +20,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_query">
-    <img src="https://img.shields.io/crates/v/brk_query" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_query">
-    <img src="https://img.shields.io/docsrs/brk_query" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_query" alt="Size" />
-  <a href="https://deps.rs/crate/brk_query">
-    <img src="https://deps.rs/crate/brk_query/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,11 +43,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A crate that searches for datasets from either `brk_indexer` or `brk_computer` according to given parameters.
-
-It's possible to search for one or multiple dataset if they have the same index and specify range with both the `from` and `to` being optional and supporting negative values.
-
-The output will depend on the format choson which can be Markdown, Json, CSV or TSV and might vary if there is a one or mutiple datasets, and if one dataset one or multiple values.
-
-In the future, it will support more features similar to a real query engine like in a Postgres databases and presets to fetch data grouped by address, transaction or blockhash/height.

--- a/crates/brk_server/README.md
+++ b/crates/brk_server/README.md
@@ -1,39 +1,17 @@
 # BRK Server
 
-<p align="left">
-  <a href="https://github.com/bitcoinresearchkit/brk">
-    <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
-  </a>
-  <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
-    <img src="https://img.shields.io/crates/l/brk" alt="License" />
-  </a>
-  <a href="https://crates.io/crates/brk_server">
-    <img src="https://img.shields.io/crates/v/brk_server" alt="Version" />
-  </a>
-  <a href="https://docs.rs/brk_server">
-    <img src="https://img.shields.io/docsrs/brk_server" alt="Documentation" />
-  </a>
-  <img src="https://img.shields.io/crates/size/brk_server" alt="Size" />
-  <a href="https://deps.rs/crate/brk_server">
-    <img src="https://deps.rs/crate/brk_server/latest/status.svg" alt="Dependency status">
-  </a>
-  <a href="https://discord.gg/HaR3wpH3nr">
-    <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
-  </a>
-  <a href="https://primal.net/p/nprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6">
-    <img src="https://img.shields.io/badge/nostr-purple?link=https%3A%2F%2Fprimal.net%2Fp%2Fnprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6" alt="Nostr" />
-  </a>
-  <a href="https://bsky.app/profile/bitcoinresearchkit.org">
-    <img src="https://img.shields.io/badge/bluesky-blue?link=https%3A%2F%2Fbsky.app%2Fprofile%2Fbitcoinresearchkit.org" alt="Bluesky" />
-  </a>
-  <a href="https://x.com/brkdotorg">
-    <img src="https://img.shields.io/badge/x.com-black" alt="X" />
-  </a>
-</p>
+This crate serves Bitcoin data within swappable front-ends, built on top of `brk_indexer`, 
+`brk_computer` and `brk_query`.
 
-A crate that serves Bitcoin data and swappable front-ends, built on top of `brk_indexer`, `brk_computer` and `brk_query`.
+BRK Server serves the website specified by the user. The website can be *no website*, *default*, 
+or *custom* (which is a blank folder for people to experiment). 
 
-The file handler, will serve the website specified by the user if any, which can be *no website*, *default* or *custom* (which is a blank folder for people to experiment). If a website is specified and the server is ran outside of the brk project and thus can't find the requested website, it will download the whole project with the correct version from Github and store it in `.brk` to be able to serve to website. This is due to the crate size limit on [crates.io](https://crates.io) and the various shenanigans that need to be done to have a website in a crate.
+> [!TIP]
+> **### Due to the [crates.io](https://crates.io) crate size limit, and the shenanigans required to package a website in a crate...**Optional information to help a user be more successful.
+> 
+> If a website is specified, and the server can't find it, BRK Server will download this project from Github and 
+> store it in `~/.brk/downloads/` and... there's the website it needs. 
+
 
 The API uses `brk_query` and so inherites all of its features including formats.
 
@@ -129,3 +107,35 @@ The version of the server and thus BRK.
 Catch all.
 
 When no pattern is found, the server will look for a match inside the folder of the chosen website, if any.
+
+----
+<p align="left">
+  <a href="https://github.com/bitcoinresearchkit/brk">
+    <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
+  </a>
+  <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
+    <img src="https://img.shields.io/crates/l/brk" alt="License" />
+  </a>
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
+  </a>
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
+  </a>
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
+  </a>
+  <a href="https://discord.gg/HaR3wpH3nr">
+    <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
+  </a>
+  <a href="https://primal.net/p/nprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6">
+    <img src="https://img.shields.io/badge/nostr-purple?link=https%3A%2F%2Fprimal.net%2Fp%2Fnprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6" alt="Nostr" />
+  </a>
+  <a href="https://bsky.app/profile/bitcoinresearchkit.org">
+    <img src="https://img.shields.io/badge/bluesky-blue?link=https%3A%2F%2Fbsky.app%2Fprofile%2Fbitcoinresearchkit.org" alt="Bluesky" />
+  </a>
+  <a href="https://x.com/brkdotorg">
+    <img src="https://img.shields.io/badge/x.com-black" alt="X" />
+  </a>
+</p>

--- a/crates/brk_store/README.md
+++ b/crates/brk_store/README.md
@@ -1,1 +1,35 @@
 # BRK Store
+
+🏪
+
+----
+<p align="left">
+  <a href="https://github.com/bitcoinresearchkit/brk">
+    <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
+  </a>
+  <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
+    <img src="https://img.shields.io/crates/l/brk" alt="License" />
+  </a>
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
+  </a>
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
+  </a>
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
+  </a>
+  <a href="https://discord.gg/HaR3wpH3nr">
+    <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
+  </a>
+  <a href="https://primal.net/p/nprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6">
+    <img src="https://img.shields.io/badge/nostr-purple?link=https%3A%2F%2Fprimal.net%2Fp%2Fnprofile1qqsfw5dacngjlahye34krvgz7u0yghhjgk7gxzl5ptm9v6n2y3sn03sqxu2e6" alt="Nostr" />
+  </a>
+  <a href="https://bsky.app/profile/bitcoinresearchkit.org">
+    <img src="https://img.shields.io/badge/bluesky-blue?link=https%3A%2F%2Fbsky.app%2Fprofile%2Fbitcoinresearchkit.org" alt="Bluesky" />
+  </a>
+  <a href="https://x.com/brkdotorg">
+    <img src="https://img.shields.io/badge/x.com-black" alt="X" />
+  </a>
+</p>

--- a/crates/brk_vec/README.md
+++ b/crates/brk_vec/README.md
@@ -1,5 +1,17 @@
 # BRK Vec
 
+A `Vec` (an array) that is stored on disk and thus which can be much larger than the available RAM.
+
+Compared to a key/value store, the data stored is raw byte interpretation of the Vec's values 
+without any overhead which is very efficient. Additionally it uses close to no RAM when caching 
+isn't active and up to 100 MB when it is.
+
+Compression is also available and built on top [`zstd`](https://crates.io/crates/zstd) to save even 
+more space (from 0 to 75%). The tradeoff being slower reading speeds, especially random reading 
+speeds. This is due to the data being stored in compressed pages of 16 KB, which means that if you 
+to read even one value in that page you have to uncompress the whole page.
+
+----
 <p align="left">
   <a href="https://github.com/bitcoinresearchkit/brk">
     <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/bitcoinresearchkit/brk?style=social">
@@ -7,15 +19,15 @@
   <a href="https://github.com/bitcoinresearchkit/brk/blob/main/LICENSE.md">
     <img src="https://img.shields.io/crates/l/brk" alt="License" />
   </a>
-  <a href="https://crates.io/crates/brk_vec">
-    <img src="https://img.shields.io/crates/v/brk_vec" alt="Version" />
+  <a href="https://crates.io/crates/brk_cli">
+    <img src="https://img.shields.io/crates/v/brk_cli" alt="Version" />
   </a>
-  <a href="https://docs.rs/brk_vec">
-    <img src="https://img.shields.io/docsrs/brk_vec" alt="Documentation" />
+  <a href="https://docs.rs/brk_cli">
+    <img src="https://img.shields.io/docsrs/brk_cli" alt="Documentation" />
   </a>
-  <img src="https://img.shields.io/crates/size/brk_vec" alt="Size" />
-  <a href="https://deps.rs/crate/brk_vec">
-    <img src="https://deps.rs/crate/brk_vec/latest/status.svg" alt="Dependency status">
+  <img src="https://img.shields.io/crates/size/brk_cli" alt="Size" />
+  <a href="https://deps.rs/crate/brk_cli">
+    <img src="https://deps.rs/crate/brk_cli/latest/status.svg" alt="Dependency status">
   </a>
   <a href="https://discord.gg/HaR3wpH3nr">
     <img src="https://img.shields.io/discord/1350431684562124850?label=discord" alt="Discord" />
@@ -30,9 +42,3 @@
     <img src="https://img.shields.io/badge/x.com-black" alt="X" />
   </a>
 </p>
-
-A `Vec` (an array) that is stored on disk and thus which can be much larger than the available RAM.
-
-Compared to a key/value store, the data stored is raw byte interpretation of the Vec's values without any overhead which is very efficient. Additionally it uses close to no RAM when caching isn't active and up to 100 MB when it is.
-
-Compression is also available and built on top [`zstd`](https://crates.io/crates/zstd) to save even more space (from 0 to 75%). The tradeoff being slower reading speeds, especially random reading speeds. This is due to the data being stored in compressed pages of 16 KB, which means that if you to read even one value in that page you have to uncompress the whole page.


### PR DESCRIPTION
If merged, the following changes are applied to README files throughout.

* Minor corrections to grammar, sentence structure, etc.

* README files now have a soft wrap limit at column 100.  **Take note!** The Github flavoured markdown highlight classes like [TIP] and [IMPORTANT] typically shouldn't be force-wrapped at column 100.

* Github badges probably don't need to be on ever inner-README. They certainly should not block the first 25-lines of viewport in every README; Github badges are moved to the bottom of the inner README files.