### PR TITLE
[codex] add brk_server response tests

### DIFF
--- a/crates/brk_server/src/error.rs
+++ b/crates/brk_server/src/error.rs
@@ -168,3 +168,63 @@ impl IntoResponse for Error {
             .into_response()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::to_bytes,
+        http::{
+            StatusCode,
+            header::{CACHE_CONTROL, CONTENT_TYPE, ETAG},
+        },
+        response::IntoResponse,
+    };
+    use brk_error::Error as BrkError;
+
+    use super::Error;
+
+    #[tokio::test]
+    async fn into_response_serializes_problem_json() {
+        let response = Error::bad_request("bad input").into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "application/problem+json",
+        );
+
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(parsed["error"]["type"], "invalid_request");
+        assert_eq!(parsed["error"]["code"], "bad_request");
+        assert_eq!(parsed["error"]["message"], "bad input");
+        assert_eq!(parsed["error"]["doc_url"], "/api");
+    }
+
+    #[tokio::test]
+    async fn into_response_with_etag_sets_cache_headers() {
+        let response = Error::not_found("missing").into_response_with_etag("v1");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.headers().get(ETAG).unwrap(), "\"v1\"");
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL).unwrap(),
+            "public, max-age=1, must-revalidate",
+        );
+    }
+
+    #[tokio::test]
+    async fn from_brk_error_maps_status_and_code() {
+        let response = Error::from(BrkError::MempoolNotAvailable).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(parsed["error"]["type"], "unavailable");
+        assert_eq!(parsed["error"]["code"], "mempool_not_available");
+        assert_eq!(parsed["error"]["message"], "Mempool data is not available");
+    }
+}

--- a/crates/brk_server/src/extended/header_map.rs
+++ b/crates/brk_server/src/extended/header_map.rs
@@ -75,3 +75,39 @@ impl HeaderMapExtended for HeaderMap {
         self.insert("Sunset", sunset.parse().unwrap());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::http::header::{ETAG, IF_NONE_MATCH};
+
+    use super::HeaderMapExtended;
+
+    #[test]
+    fn has_etag_matches_quoted_and_unquoted_values() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, "\"abc123\"".parse().unwrap());
+
+        assert!(headers.has_etag("abc123"));
+        assert!(!headers.has_etag("different"));
+    }
+
+    #[test]
+    fn insert_etag_wraps_value_in_quotes() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert_etag("abc123");
+
+        assert_eq!(headers.get(ETAG).unwrap(), "\"abc123\"");
+    }
+
+    #[test]
+    fn insert_deprecation_sets_expected_headers() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert_deprecation("Wed, 01 Jan 2027 00:00:00 GMT");
+
+        assert_eq!(headers.get("Deprecation").unwrap(), "true");
+        assert_eq!(
+            headers.get("Sunset").unwrap(),
+            "Wed, 01 Jan 2027 00:00:00 GMT",
+        );
+    }
+}

--- a/crates/brk_server/src/extended/response.rs
+++ b/crates/brk_server/src/extended/response.rs
@@ -54,3 +54,73 @@ impl ResponseExtended for Response<Body> {
         Self::new_json_cached(value, &params)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::to_bytes,
+        http::{
+            HeaderMap, StatusCode,
+            header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, IF_NONE_MATCH},
+        },
+    };
+    use serde_json::json;
+
+    use super::ResponseExtended;
+    use crate::{VERSION, cache::CacheParams};
+
+    #[tokio::test]
+    async fn new_json_cached_sets_headers_and_body() {
+        let params = CacheParams::version();
+        let response = axum::http::Response::<axum::body::Body>::new_json_cached(
+            json!({ "ok": true }),
+            &params,
+        );
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL).unwrap(),
+            "public, max-age=1, must-revalidate",
+        );
+        assert_eq!(
+            response.headers().get(ETAG).unwrap(),
+            format!("\"{VERSION}\"").as_str(),
+        );
+
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+            json!({ "ok": true })
+        );
+    }
+
+    #[tokio::test]
+    async fn static_json_returns_not_modified_for_matching_unquoted_etag() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, VERSION.parse().unwrap());
+
+        let response =
+            axum::http::Response::<axum::body::Body>::static_json(&headers, json!({ "ok": true }));
+
+        assert_eq!(response.status(), StatusCode::NOT_MODIFIED);
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn static_json_returns_not_modified_for_matching_quoted_etag() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, format!("\"{VERSION}\"").parse().unwrap());
+
+        let response =
+            axum::http::Response::<axum::body::Body>::static_json(&headers, json!({ "ok": true }));
+
+        assert_eq!(response.status(), StatusCode::NOT_MODIFIED);
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert!(body.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for brk_server response helpers and error serialization
- cover quoted and unquoted ETag matching, JSON cache headers, and structured problem responses
- validate BrkError to HTTP mapping for a representative unavailable case

## Validation
- cargo test -p brk_server