### PR TITLE
Fix store checkpoint ordering

### DIFF
--- a/crates/brk_indexer/src/lib.rs
+++ b/crates/brk_indexer/src/lib.rs
@@ -31,6 +31,10 @@ pub use safe_lengths::SafeLengths;
 pub use stores::Stores;
 pub use vecs::*;
 
+fn shared_tip_height(vecs_next_height: Height, stores_next_height: Height) -> Option<Height> {
+    vecs_next_height.min(stores_next_height).decremented()
+}
+
 pub struct Indexer<M: StorageMode = Rw> {
     path: PathBuf,
     pub vecs: Vecs<M>,
@@ -155,7 +159,14 @@ impl Indexer {
 
         debug!("Starting indexing...");
 
-        let last_blockhash = self.vecs.blocks.blockhash.collect_last();
+        let last_blockhash = shared_tip_height(self.vecs.next_height(), self.stores.next_height())
+            .and_then(|height| {
+                self.vecs
+                    .blocks
+                    .blockhash
+                    .collect_one_at(usize::from(height))
+            })
+            .or_else(|| self.vecs.blocks.blockhash.collect_last());
         // Rollback sim
         // let last_blockhash = self
         //     .vecs
@@ -360,5 +371,23 @@ impl ReadOnlyClone for Indexer {
             stores: self.stores.clone(),
             safe_lengths: self.safe_lengths.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_tip_uses_lower_checkpoint() {
+        assert_eq!(
+            shared_tip_height(Height::new(43), Height::new(40)),
+            Some(Height::new(39))
+        );
+        assert_eq!(
+            shared_tip_height(Height::new(40), Height::new(43)),
+            Some(Height::new(39))
+        );
+        assert_eq!(shared_tip_height(Height::ZERO, Height::new(43)), None);
     }
 }

--- a/crates/brk_indexer/src/lib.rs
+++ b/crates/brk_indexer/src/lib.rs
@@ -3,7 +3,6 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    thread,
     time::{Duration, Instant},
 };
 
@@ -11,7 +10,6 @@ use brk_error::Result;
 use brk_reader::{Reader, XORBytes};
 use brk_rpc::Client;
 use brk_types::{BlockHash, Height};
-use fjall::PersistMode;
 use tracing::{debug, error, info};
 use vecdb::{
     Exit, RawDBError, ReadOnlyClone, ReadableVec, Ro, Rw, StorageMode, WritableVec, unlikely,
@@ -205,23 +203,8 @@ impl Indexer {
             info!("Exporting...");
             let i = Instant::now();
             let _lock = exit.lock();
-            thread::scope(|s| -> Result<()> {
-                let stores_res = s.spawn(|| -> Result<()> {
-                    let i = Instant::now();
-                    stores.commit(height)?;
-                    debug!("Stores exported in {:?}", i.elapsed());
-                    Ok(())
-                });
-                let vecs_res = s.spawn(|| -> Result<()> {
-                    let i = Instant::now();
-                    vecs.flush(height)?;
-                    debug!("Vecs exported in {:?}", i.elapsed());
-                    Ok(())
-                });
-                stores_res.join().unwrap()?;
-                vecs_res.join().unwrap()?;
-                Ok(())
-            })?;
+            vecs.flush(height)?;
+            stores.commit(height)?;
             info!("Exported in {:?}", i.elapsed());
             Ok(())
         };
@@ -320,9 +303,8 @@ impl Indexer {
         drop(readers);
 
         let lock = exit.lock();
-        let tasks = self.stores.take_all_pending_ingests(lengths.height)?;
+        let commit = self.stores.take_pending_commit(lengths.height)?;
         self.vecs.stamped_write(lengths.height)?;
-        let fjall_db = self.stores.db.clone();
 
         self.vecs.db.run_bg(move |db| {
             let _lock = lock;
@@ -332,21 +314,8 @@ impl Indexer {
             info!("Exporting...");
             let i = Instant::now();
 
-            if !tasks.is_empty() {
-                let i = Instant::now();
-                for task in tasks {
-                    task().map_err(vecdb::RawDBError::other)?;
-                }
-                debug!("Stores committed in {:?}", i.elapsed());
-
-                let i = Instant::now();
-                fjall_db
-                    .persist(PersistMode::SyncData)
-                    .map_err(RawDBError::other)?;
-                debug!("Stores persisted in {:?}", i.elapsed());
-            }
-
             db.compact()?;
+            commit().map_err(RawDBError::other)?;
 
             info!("Exported in {:?}", i.elapsed());
             Ok(())

--- a/crates/brk_indexer/src/stores.rs
+++ b/crates/brk_indexer/src/stores.rs
@@ -228,6 +228,11 @@ impl Stores {
         }))
     }
 
+    /// Compatibility wrapper returning the ordered commit as a single task.
+    pub fn take_all_pending_ingests(&mut self, height: Height) -> Result<Vec<StoreTask>> {
+        Ok(vec![self.take_pending_commit(height)?])
+    }
+
     /// Rewrites reverse-key entries below the lowered bound. In-flight
     /// readers may briefly see torn state.
     pub fn rollback_if_needed(
@@ -442,8 +447,9 @@ mod tests {
         let key = BlockHashPrefix::from(7_u64);
         let mut stores = Stores::forced_import(&path, Version::ZERO)?;
         stores.blockhash_prefix_to_height.insert(key, height);
-        let commit = stores.take_pending_commit(height)?;
-        commit()?;
+        let mut commits = stores.take_all_pending_ingests(height)?;
+        assert_eq!(commits.len(), 1);
+        commits.pop().unwrap()()?;
 
         assert_eq!(stores.next_height(), height.incremented());
         assert_eq!(

--- a/crates/brk_indexer/src/stores.rs
+++ b/crates/brk_indexer/src/stores.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashSet;
 
 use brk_cohort::ByAddrType;
 use brk_error::Result;
-use brk_store::{AnyStore, Kind, Mode, Store};
+use brk_store::{AnyStore, Kind, Mode, Store, StoreTask};
 use brk_types::{
     AddrHash, AddrIndexOutPoint, AddrIndexTxIndex, BlockHashPrefix, Height, OutPoint, OutputType,
     TxIndex, TxOutIndex, TxidPrefix, TypeIndex, Unit, Version, Vout,
@@ -174,30 +174,25 @@ impl Stores {
 
     pub fn commit(&mut self, height: Height) -> Result<()> {
         let i = Instant::now();
+        self.ingest_and_persist()?;
         self.par_iter_any_mut()
-            .try_for_each(|store| store.commit(height))?;
+            .try_for_each(|store| store.export_meta_if_needed(height))?;
         debug!("Stores committed in {:?}", i.elapsed());
-
-        let i = Instant::now();
-        self.db.persist(PersistMode::SyncData)?;
-        debug!("Stores persisted in {:?}", i.elapsed());
 
         Ok(())
     }
 
-    /// Takes all pending puts/dels from every store and returns closures
-    /// that can ingest them on a background thread.
-    #[allow(clippy::type_complexity)]
-    pub fn take_all_pending_ingests(
-        &mut self,
-        height: Height,
-    ) -> Result<Vec<Box<dyn FnOnce() -> Result<()> + Send>>> {
+    /// Takes all pending puts/dels and returns one ordered background commit.
+    pub fn take_pending_commit(&mut self, height: Height) -> Result<StoreTask> {
         let h = height;
-        let mut tasks = Vec::new();
+        let mut ingests = Vec::new();
+        let mut checkpoints = Vec::new();
 
         macro_rules! take {
             ($store:expr) => {
-                tasks.extend($store.take_pending_ingest(h)?);
+                let (ingest, checkpoint) = $store.take_pending_ingest_parts(h)?;
+                ingests.extend(ingest);
+                checkpoints.push(checkpoint);
             };
         }
 
@@ -217,7 +212,20 @@ impl Stores {
             take!(store);
         }
 
-        Ok(tasks)
+        let db = self.db.clone();
+
+        Ok(Box::new(move || {
+            if !ingests.is_empty() {
+                for ingest in ingests {
+                    ingest()?;
+                }
+                db.persist(PersistMode::SyncData)?;
+            }
+            for checkpoint in checkpoints {
+                checkpoint()?;
+            }
+            Ok(())
+        }))
     }
 
     /// Rewrites reverse-key entries below the lowered bound. In-flight
@@ -241,8 +249,19 @@ impl Stores {
 
         let rollback_height = starting_lengths.height.decremented().unwrap_or_default();
         self.par_iter_any_mut()
-            .try_for_each(|store| store.export_meta(rollback_height))?;
-        self.commit(rollback_height)?;
+            .try_for_each(|store| store.export_meta_sync(rollback_height))?;
+        self.ingest_and_persist()?;
+
+        Ok(())
+    }
+
+    fn ingest_and_persist(&mut self) -> Result<()> {
+        self.par_iter_any_mut()
+            .try_for_each(|store| store.ingest_pending())?;
+
+        let i = Instant::now();
+        self.db.persist(PersistMode::SyncData)?;
+        debug!("Stores persisted in {:?}", i.elapsed());
 
         Ok(())
     }
@@ -402,5 +421,52 @@ impl Stores {
                 .get_mut_unwrap(addr_type)
                 .remove(AddrIndexTxIndex::from((addr_index, tx_index)));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, process};
+
+    use super::*;
+
+    #[test]
+    fn pending_commit_persists_data_and_all_checkpoints() -> Result<()> {
+        let path = std::env::temp_dir().join(format!(
+            "brk-indexer-empty-store-checkpoints-{}",
+            process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+
+        let height = Height::new(42);
+        let key = BlockHashPrefix::from(7_u64);
+        let mut stores = Stores::forced_import(&path, Version::ZERO)?;
+        stores.blockhash_prefix_to_height.insert(key, height);
+        let commit = stores.take_pending_commit(height)?;
+        commit()?;
+
+        assert_eq!(stores.next_height(), height.incremented());
+        assert_eq!(
+            stores
+                .blockhash_prefix_to_height
+                .get(&key)?
+                .map(|value| *value),
+            Some(height)
+        );
+        drop(stores);
+
+        let stores = Stores::forced_import(&path, Version::ZERO)?;
+        assert_eq!(stores.next_height(), height.incremented());
+        assert_eq!(
+            stores
+                .blockhash_prefix_to_height
+                .get(&key)?
+                .map(|value| *value),
+            Some(height)
+        );
+        drop(stores);
+        fs::remove_dir_all(path)?;
+
+        Ok(())
     }
 }

--- a/crates/brk_store/src/any.rs
+++ b/crates/brk_store/src/any.rs
@@ -1,4 +1,4 @@
-use brk_error::Result;
+use brk_error::{Error, Result};
 use brk_types::{Height, Version};
 use fjall::Keyspace;
 
@@ -9,7 +9,15 @@ pub trait AnyStore: Send + Sync {
     fn needs(&self, height: Height) -> bool;
     fn version(&self) -> Version;
     fn export_meta(&mut self, height: Height) -> Result<()>;
+    #[doc(hidden)]
+    fn export_meta_sync(&mut self, height: Height) -> Result<()> {
+        self.export_meta(height)
+    }
     fn export_meta_if_needed(&mut self, height: Height) -> Result<()>;
+    #[doc(hidden)]
+    fn ingest_pending(&mut self) -> Result<()> {
+        Err(Error::Internal("pending ingestion is not implemented"))
+    }
     fn keyspace(&self) -> &Keyspace;
     fn commit(&mut self, height: Height) -> Result<()>;
 }

--- a/crates/brk_store/src/lib.rs
+++ b/crates/brk_store/src/lib.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, fmt::Debug, fs, hash::Hash, mem, ops::Range, path::Path};
 use brk_error::Result;
 use brk_types::{Height, Version};
 use byteview::ByteView;
-use fjall::{Database, Keyspace, KeyspaceCreateOptions, config::*};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode, config::*};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 mod any;
@@ -22,6 +22,8 @@ pub use mode::*;
 
 const MAJOR_FJALL_VERSION: Version = Version::new(3);
 
+pub type StoreTask = Box<dyn FnOnce() -> Result<()> + Send>;
+
 pub fn open_database(path: &Path) -> fjall::Result<Database> {
     Database::builder(path.join("fjall"))
         .cache_size(3 * 1024 * 1024 * 1024)
@@ -31,6 +33,7 @@ pub fn open_database(path: &Path) -> fjall::Result<Database> {
 
 #[derive(Clone)]
 pub struct Store<K, V> {
+    database: Database,
     meta: StoreMeta,
     name: &'static str,
     keyspace: Keyspace,
@@ -97,6 +100,7 @@ where
         }
 
         Ok(Self {
+            database: db.clone(),
             meta,
             name: Box::leak(Box::new(name.to_string())),
             keyspace,
@@ -199,32 +203,71 @@ where
         }
     }
 
-    /// Takes buffered puts/dels and returns a closure that ingests them into the keyspace.
-    /// The store is left with empty buffers, ready for the next batch.
-    #[allow(clippy::type_complexity)]
-    pub fn take_pending_ingest(
-        &mut self,
-        height: Height,
-    ) -> Result<Option<Box<dyn FnOnce() -> Result<()> + Send>>>
+    /// Takes buffered puts/dels and returns a durable background commit.
+    pub fn take_pending_ingest(&mut self, height: Height) -> Result<Option<StoreTask>>
     where
         K: Send + 'static,
         V: Send + 'static,
         for<'a> ByteView: From<&'a K> + From<&'a V>,
     {
-        self.export_meta_if_needed(height)?;
+        let (ingest, checkpoint) = self.take_pending_ingest_parts(height)?;
+        let Some(ingest) = ingest else {
+            checkpoint()?;
+            return Ok(None);
+        };
+        let database = self.database.clone();
 
+        Ok(Some(Box::new(move || {
+            ingest()?;
+            database.persist(PersistMode::SyncData)?;
+            checkpoint()
+        })))
+    }
+
+    /// Takes buffered puts/dels and returns separate ingest and checkpoint tasks.
+    ///
+    /// The indexer uses this to persist one batch across all stores before
+    /// publishing any of their checkpoints.
+    #[doc(hidden)]
+    #[allow(clippy::type_complexity)]
+    pub fn take_pending_ingest_parts(
+        &mut self,
+        height: Height,
+    ) -> Result<(Option<StoreTask>, StoreTask)>
+    where
+        K: Send + 'static,
+        V: Send + 'static,
+        for<'a> ByteView: From<&'a K> + From<&'a V>,
+    {
         let puts = mem::take(&mut self.puts);
         let dels = mem::take(&mut self.dels);
 
-        if puts.is_empty() && dels.is_empty() {
-            return Ok(None);
-        }
+        let meta = self.meta.clone();
+        let checkpoint = Box::new(move || {
+            if meta.needs(height) {
+                meta.export(height)?;
+            }
+            Ok(())
+        });
 
-        let keyspace = self.keyspace.clone();
+        let ingest = if puts.is_empty() && dels.is_empty() {
+            None
+        } else {
+            let keyspace = self.keyspace.clone();
+            Some(Box::new(move || Self::ingest(&keyspace, puts.iter(), dels.iter())) as StoreTask)
+        };
 
-        Ok(Some(Box::new(move || {
-            Self::ingest(&keyspace, puts.iter(), dels.iter())
-        })))
+        Ok((ingest, checkpoint))
+    }
+
+    /// Ingests buffered writes, persists them, then publishes their height.
+    pub fn commit(&mut self, height: Height) -> Result<()>
+    where
+        for<'a> ByteView: From<&'a K> + From<&'a V>,
+    {
+        self.ingest_pending()?;
+        self.database.persist(PersistMode::SyncData)?;
+        self.export_meta_if_needed(height)
     }
 
     #[inline]
@@ -286,6 +329,27 @@ where
         Ok(())
     }
 
+    fn ingest_pending(&mut self) -> Result<()>
+    where
+        for<'a> ByteView: From<&'a K> + From<&'a V>,
+    {
+        let puts = mem::take(&mut self.puts);
+        let dels = mem::take(&mut self.dels);
+
+        if puts.is_empty() && dels.is_empty() {
+            return Ok(());
+        }
+
+        Self::ingest(&self.keyspace, puts.iter(), dels.iter())?;
+
+        if !self.caches.is_empty() {
+            self.caches.pop();
+            self.caches.insert(0, puts);
+        }
+
+        Ok(())
+    }
+
     fn ingest<'a>(
         keyspace: &Keyspace,
         puts: impl Iterator<Item = (&'a K, &'a V)>,
@@ -335,8 +399,17 @@ where
         self.export_meta(height)
     }
 
+    fn export_meta_sync(&mut self, height: Height) -> Result<()> {
+        self.meta.export_sync(height)?;
+        Ok(())
+    }
+
     fn export_meta_if_needed(&mut self, height: Height) -> Result<()> {
         self.export_meta_if_needed(height)
+    }
+
+    fn ingest_pending(&mut self) -> Result<()> {
+        self.ingest_pending()
     }
 
     fn name(&self) -> &'static str {
@@ -360,21 +433,116 @@ where
     }
 
     fn commit(&mut self, height: Height) -> Result<()> {
-        self.export_meta_if_needed(height)?;
+        self.commit(height)
+    }
+}
 
-        let puts = mem::take(&mut self.puts);
-        let dels = mem::take(&mut self.dels);
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        process,
+    };
 
-        if puts.is_empty() && dels.is_empty() {
-            return Ok(());
+    use brk_types::Unit;
+
+    use super::*;
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!("brk-store-{name}-{}", process::id()));
+            let _ = fs::remove_dir_all(&path);
+            Self(path)
         }
+    }
 
-        Self::ingest(&self.keyspace, puts.iter(), dels.iter())?;
-
-        if !self.caches.is_empty() {
-            self.caches.pop();
-            self.caches.insert(0, puts);
+    impl AsRef<Path> for TestDir {
+        fn as_ref(&self) -> &Path {
+            &self.0
         }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn import_test_store(db: &Database, path: &Path) -> Result<Store<Height, Unit>> {
+        Store::import(db, path, "test", Version::ZERO, Mode::Any, Kind::Random)
+    }
+
+    #[test]
+    fn dropped_pending_ingest_does_not_advance_checkpoint() -> Result<()> {
+        let path = TestDir::new("dropped-ingest");
+        let height = Height::new(42);
+        let key = Height::new(7);
+
+        let db = open_database(path.as_ref())?;
+        let mut store = import_test_store(&db, path.as_ref())?;
+        store.insert(key, Unit);
+
+        let ingest = store.take_pending_ingest(height)?;
+        assert!(store.needs(height));
+        drop(ingest);
+        drop(store);
+        drop(db);
+
+        let db = open_database(path.as_ref())?;
+        let store = import_test_store(&db, path.as_ref())?;
+        assert!(store.needs(height));
+        assert!(store.get(&key)?.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn successful_pending_ingest_advances_checkpoint() -> Result<()> {
+        let path = TestDir::new("successful-ingest");
+        let height = Height::new(42);
+        let key = Height::new(7);
+
+        let db = open_database(path.as_ref())?;
+        let mut store = import_test_store(&db, path.as_ref())?;
+        store.insert(key, Unit);
+
+        let ingest = store.take_pending_ingest(height)?;
+        ingest.unwrap()()?;
+
+        assert!(!store.needs(height));
+        assert!(store.get(&key)?.is_some());
+        drop(store);
+        drop(db);
+
+        let db = open_database(path.as_ref())?;
+        let store = import_test_store(&db, path.as_ref())?;
+        assert!(!store.needs(height));
+        assert!(store.get(&key)?.is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn failed_checkpoint_write_keeps_old_height() -> Result<()> {
+        let path = TestDir::new("failed-checkpoint");
+        let height = Height::new(42);
+        let key = Height::new(7);
+
+        let db = open_database(path.as_ref())?;
+        let mut store = import_test_store(&db, path.as_ref())?;
+        store.insert(key, Unit);
+
+        let (ingest, checkpoint) = store.take_pending_ingest_parts(height)?;
+        ingest.unwrap()()?;
+        db.persist(PersistMode::SyncData)?;
+        fs::remove_dir_all(path.as_ref().join("meta/test"))?;
+
+        assert!(checkpoint().is_err());
+        assert!(store.needs(height));
+        assert!(store.get(&key)?.is_some());
 
         Ok(())
     }

--- a/crates/brk_store/src/meta.rs
+++ b/crates/brk_store/src/meta.rs
@@ -1,6 +1,10 @@
 use std::{
     fs, io,
     path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use brk_error::{Error, Result};
@@ -13,10 +17,12 @@ use super::Height;
 pub struct StoreMeta {
     pathbuf: PathBuf,
     version: Version,
-    height: Option<Height>,
+    height: Arc<AtomicU64>,
 }
 
 impl StoreMeta {
+    const NO_HEIGHT: u64 = u64::MAX;
+
     pub fn checked_open<F>(
         path: &Path,
         version: Version,
@@ -42,7 +48,11 @@ impl StoreMeta {
         let slf = Self {
             pathbuf: path.to_owned(),
             version,
-            height: Height::try_from(Self::path_height_(path).as_path()).ok(),
+            height: Arc::new(AtomicU64::new(
+                Height::try_from(Self::path_height_(path).as_path())
+                    .map(u64::from)
+                    .unwrap_or(Self::NO_HEIGHT),
+            )),
         };
 
         slf.version.write(&slf.path_version())?;
@@ -54,9 +64,18 @@ impl StoreMeta {
         self.version
     }
 
-    pub fn export(&mut self, height: Height) -> io::Result<()> {
-        self.height = Some(height);
-        height.write(&self.path_height())
+    pub fn export(&self, height: Height) -> io::Result<()> {
+        height.write(&self.path_height())?;
+        self.height.store(height.into(), Ordering::Release);
+        Ok(())
+    }
+
+    pub fn export_sync(&self, height: Height) -> io::Result<()> {
+        let path = self.path_height();
+        height.write(&path)?;
+        fs::File::open(path)?.sync_data()?;
+        self.height.store(height.into(), Ordering::Release);
+        Ok(())
     }
 
     pub fn path(&self) -> &Path {
@@ -72,22 +91,23 @@ impl StoreMeta {
 
     #[inline]
     pub fn height(&self) -> Option<Height> {
-        self.height
+        let height = self.height.load(Ordering::Acquire);
+        (height != Self::NO_HEIGHT).then(|| Height::from(height))
     }
     #[inline]
     pub fn needs(&self, height: Height) -> bool {
-        self.height.is_none_or(|self_height| height > self_height)
+        self.height().is_none_or(|self_height| height > self_height)
     }
     #[inline]
     pub fn has(&self, height: Height) -> bool {
         !self.needs(height)
     }
-    pub fn reset(&mut self) -> io::Result<()> {
-        self.height = None;
+    pub fn reset(&self) -> io::Result<()> {
         let path = self.path_height();
         if path.exists() {
             fs::remove_file(&path)?;
         }
+        self.height.store(Self::NO_HEIGHT, Ordering::Release);
         Ok(())
     }
     fn path_height(&self) -> PathBuf {


### PR DESCRIPTION
## Summary

- persist Fjall mutations before publishing completed-height checkpoints
- keep background checkpoint tasks synchronized with the live store metadata
- persist vectors before the ordered store commit
- recover from the lower shared checkpoint if a crash leaves backends uneven
- preserve the public `Stores::take_all_pending_ingests` batching API
- cover dropped, successful, failed, aggregate, reopen, and uneven-tip cases

## Root cause

`Store::take_pending_ingest` previously wrote its completed-height metadata
before the returned deferred ingest closure ran. A crash or ingest failure in
that window left a checkpoint claiming a height was complete even though its
transaction, address, or UTXO mutations were missing. Restart then trusted the
checkpoint and skipped the missing work.

This change treats the height as the final commit marker. Forward commits now
ingest all pending mutations, persist Fjall with `SyncData`, and only then
publish checkpoints. The background indexer persists vector data before
running that ordered store commit. Rollback uses the conservative inverse:
persist the lowered checkpoints first, then persist destructive removals.

If a crash leaves vectors ahead of store checkpoints, startup now selects the
lower shared durable tip. Store rollback consumes the still-ahead vector
history before vector truncation, then normal replay resumes without a full
rebuild. The former public batching method remains available as a compatibility
wrapper around the single ordered task.

## Impact

Interrupted indexing can no longer leave store metadata ahead of durable Fjall
data. Data or vectors may lead a checkpoint after a failure, which is safe
because BRK recovers from the shared checkpoint and replays the affected
height.

## Validation

- `cargo test -p brk_store -p brk_indexer --lib`
- `cargo test --workspace`
- `cargo check -p brk_indexer --all-targets`
- `cargo clippy -p brk_store -p brk_indexer --lib --tests --no-deps -- -D warnings`
- `cargo package --workspace --allow-dirty --no-verify`
- `rustfmt --check` on the changed store files and
  `crates/brk_indexer/src/stores.rs`
- `git diff --check`

All commands above pass. A full-file rustfmt check of
`crates/brk_indexer/src/lib.rs` still reports an unchanged pre-existing
formatting difference outside this PR's hunks.

The repository's unchanged JavaScript/Python release harnesses were also
attempted. They are currently broken on `main`: the generated-client tests use
the removed `series.prices` path, and the Python mempool-compat suite imports
untracked `_lib.py` and `_endpoints.py` helpers. Neither suite exercises the
changed Rust persistence flow.

Fixes #39
